### PR TITLE
Fix Frends.Tasks.Attributes reference to a working version (1.2.1)

### DIFF
--- a/Frends.Sql/Frends.Sql.csproj
+++ b/Frends.Sql/Frends.Sql.csproj
@@ -37,8 +37,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Frends.Tasks.Attributes, Version=1.2.0.0, Culture=neutral, PublicKeyToken=258fd606323928fc, processorArchitecture=MSIL">
-      <HintPath>..\packages\Frends.Tasks.Attributes.1.2.0\lib\net40\Frends.Tasks.Attributes.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\packages\Frends.Tasks.Attributes.1.2.1\lib\net40\Frends.Tasks.Attributes.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.6.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>

--- a/Frends.Sql/packages.config
+++ b/Frends.Sql/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Dapper" version="1.50.2" targetFramework="net452" />
-  <package id="Frends.Tasks.Attributes" version="1.2.0" targetFramework="net452" />
+  <package id="Frends.Tasks.Attributes" version="1.2.1" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net452" />
 </packages>

--- a/README.md
+++ b/README.md
@@ -3,23 +3,10 @@
    - [Building](#building)
    - [Contributing](#contributing)
    - [Documentation](#documentation)
-     - [Sql.ExecuteQuery](#sql.executequery)
-       - [Input](#input)
-       - [Options](#options)
-       - [Result](#result)
-     - [Sql.ExecuteProcedure](#sql.executeprocedure)
-       - [Input](#input)
-       - [Options](#options)
-       - [Result](#result)
-     - [Sql.BulkInsert](#sql.bulkinsert)
-       - [Input](#input)
-       - [Options](#options)
-       - [Result](#result)
-     - [Sql.BatchOperation](#sql.batchoperation)
-       - [Input](#input)
-       - [Options](#options)
-       - [Result](#result)
-       - [Example usage](#example-usage)
+     - [Sql.ExecuteQuery](#sqlexecutequery) 
+     - [Sql.ExecuteProcedure](#sqlexecuteprocedure) 
+     - [Sql.BulkInsert](#sqlbulkinsert)
+     - [Sql.BatchOperation](#sqlbatchoperation) 
    - [License](#license)
 
 # Frends.Sql
@@ -30,8 +17,6 @@ You can install the task via FRENDS UI Task view or you can find the nuget packa
 `https://www.myget.org/F/frends/api/v2`
 
 ## Building
-Ensure that you have `https://www.myget.org/F/frends/api/v2` added to your nuget feeds
-
 Clone a copy of the repo
 
 `git clone https://github.com/FrendsPlatform/Frends.Sql.git`

--- a/nuspec/Frends.Sql.nuspec
+++ b/nuspec/Frends.Sql.nuspec
@@ -11,7 +11,6 @@
     <summary />
     <dependencies>
       <dependency id="Newtonsoft.Json" version="6.0.8" />
-	    <dependency id="Frends.Tasks.Attributes" version="1.2.0" />
       <dependency id="Dapper" version="1.50.2" />
     </dependencies>
     <frameworkAssemblies>
@@ -20,7 +19,7 @@
     </frameworkAssemblies>
   </metadata>
   <files>
-	  <file src="Frends.Sql\bin\Release\Frends.Sql.dll" target="lib\net452\Frends.Sql.dll" />	
+	  <file src="Frends.Sql\bin\Release\Frends.Sql.dll" target="lib\net452\Frends.Sql.dll" />
     <file src="Frends.Sql\bin\Release\Frends.Sql.XML" target="Frends.Sql.XML"/>
     <file src="Frends.Sql\FrendsTaskMetadata.json" target="FrendsTaskMetadata.json"/>
   </files>


### PR DESCRIPTION
The Frends.Tasks.Attributes package version 1.2.0 cannot be used as it has the wrong assembly version, so compilation will fail.