### PR TITLE
Replaced Frends.tasks.attributes with System.ComponentModel.DataAnnotations

### DIFF
--- a/Frends.Sql/Frends.Sql.csproj
+++ b/Frends.Sql/Frends.Sql.csproj
@@ -36,14 +36,12 @@
       <HintPath>..\packages\Dapper.1.50.2\lib\net451\Dapper.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Frends.Tasks.Attributes, Version=1.2.0.0, Culture=neutral, PublicKeyToken=258fd606323928fc, processorArchitecture=MSIL">
-      <HintPath>..\packages\Frends.Tasks.Attributes.1.2.1\lib\net40\Frends.Tasks.Attributes.dll</HintPath>
-    </Reference>
     <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.6.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />

--- a/Frends.Sql/Sql.cs
+++ b/Frends.Sql/Sql.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.ComponentModel.DataAnnotations;
 using System.Data;
 using System.Data.SqlClient;
 using System.Dynamic;
@@ -8,7 +9,6 @@ using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Xml;
-using Frends.Tasks.Attributes;
 using Newtonsoft.Json.Linq;
 using Dapper;
 using Newtonsoft.Json;
@@ -31,14 +31,14 @@ namespace Frends.Sql
         /// <summary>
         /// Query string for batch operation.
         /// </summary>
-        [DefaultDisplayType(DisplayType.Sql)]
+        [DisplayFormat(DataFormatString = "Sql")]
         [DefaultValue("insert into MyTable(ID,NAME) VALUES (@Id, @FirstName)")]
         public string Query { get; set; }
 
         /// <summary>
         /// Input json for batch operation. Needs to be a Json array.
         /// </summary>
-        [DefaultDisplayType(DisplayType.Json)]
+        [DisplayFormat(DataFormatString = "Json")]
         [DefaultValue("[{\"Id\":15,\"FirstName\":\"Foo\"},{\"Id\":20,\"FirstName\":\"Bar\"}]")]
         public string InputJson { get; set; }
 
@@ -72,7 +72,7 @@ namespace Frends.Sql
         /// <summary>
         /// Query text.
         /// </summary>
-        [DefaultDisplayType(DisplayType.Sql)]
+        [DisplayFormat(DataFormatString = "Sql")]
         public string Query { get; set; }
         /// <summary>
         /// Parameters for query.
@@ -106,7 +106,7 @@ namespace Frends.Sql
         /// <summary>
         /// Json Array of objects. All object property names need to match with the destination table column names.
         /// </summary>
-        [DefaultDisplayType(DisplayType.Json)]
+        [DisplayFormat(DataFormatString = "Json")]
         [DefaultValue("[{\"Column1\":\"Value1\", \"Column2\":15},{\"Column1\":\"Value2\", \"Column2\":30}]")]
         public string InputData { get; set; }
 
@@ -156,7 +156,7 @@ namespace Frends.Sql
         /// <param name="input">Input parameters</param>
         /// <param name="options">Optional parameters with default values</param>
         /// <returns>JToken</returns>
-        public static async Task<object> ExecuteQuery([CustomDisplay(DisplayOption.Tab)]InputQuery input, [CustomDisplay(DisplayOption.Tab)]Options options, CancellationToken cancellationToken)
+        public static async Task<object> ExecuteQuery([PropertyTab]InputQuery input, [PropertyTab]Options options, CancellationToken cancellationToken)
         {
             return await GetSqlCommandResult(input.Query, input.ConnectionString, input.Parameters, options, SqlCommandType.Text, cancellationToken).ConfigureAwait(false);
         }
@@ -167,7 +167,7 @@ namespace Frends.Sql
         /// <param name="input">Input parameters</param>
         /// <param name="options">Optional parameters with default values</param>
         /// <returns>JToken</returns>
-        public static async Task<object> ExecuteProcedure([CustomDisplay(DisplayOption.Tab)]InputProcedure input, [CustomDisplay(DisplayOption.Tab)]Options options, CancellationToken cancellationToken)
+        public static async Task<object> ExecuteProcedure([PropertyTab]InputProcedure input, [PropertyTab]Options options, CancellationToken cancellationToken)
         {
             return await GetSqlCommandResult(input.Execute, input.ConnectionString, input.Parameters, options, SqlCommandType.StoredProcedure, cancellationToken).ConfigureAwait(false);
         }
@@ -178,7 +178,7 @@ namespace Frends.Sql
         /// <param name="input">Input parameters</param>
         /// <param name="options">Optional parameters with default values</param>
         /// <returns>Number of affected rows</returns>
-        public static async Task<int> BatchOperation([CustomDisplay(DisplayOption.Tab)]InputBatchOperation input, [CustomDisplay(DisplayOption.Tab)]Options options, CancellationToken cancellationToken)
+        public static async Task<int> BatchOperation([PropertyTab]InputBatchOperation input, [PropertyTab]Options options, CancellationToken cancellationToken)
         {
             using (var sqlConnection = new SqlConnection(input.ConnectionString))
             {
@@ -223,7 +223,7 @@ namespace Frends.Sql
         /// <param name="input">Input parameters</param>
         /// <param name="options">Optional parameters with default values</param>
         /// <returns>Copied row count</returns>
-        public static async Task<int> BulkInsert([CustomDisplay(DisplayOption.Tab)]BulkInsertInput input, [CustomDisplay(DisplayOption.Tab)]BulkInsertOptions options, CancellationToken cancellationToken)
+        public static async Task<int> BulkInsert([PropertyTab]BulkInsertInput input, [PropertyTab]BulkInsertOptions options, CancellationToken cancellationToken)
         {
             var inputJson = "{\"Table\" : " + input.InputData + " }";
             var dataset = JsonConvert.DeserializeObject<DataSet>(inputJson);

--- a/Frends.Sql/packages.config
+++ b/Frends.Sql/packages.config
@@ -1,6 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Dapper" version="1.50.2" targetFramework="net452" />
-  <package id="Frends.Tasks.Attributes" version="1.2.1" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net452" />
 </packages>


### PR DESCRIPTION
Replaced usage of custom attributes from Frends.tasks.attributes with their counterparts from System.ComponentModel.DataAnnotations, as the Frends.Tasks.Attributes reference mostly does not work together with older versions